### PR TITLE
Join collector

### DIFF
--- a/tests/join_tests/join_common.hpp
+++ b/tests/join_tests/join_common.hpp
@@ -28,12 +28,14 @@
 // includes
 #include<cmath>
 #include<string>
+#include<mutex>
 
 using namespace std;
 using namespace wf;
 
 // Global variable for the result
 atomic<long> global_sum;
+static mutex print_mutex;
 
 // Struct of the input tuple
 struct tuple_t
@@ -168,6 +170,10 @@ public:
         tuple_t out;
         out.value = a.value * b.value;
         out.key = a.key;
+        /* {
+            lock_guard lock {print_mutex};
+            std:cout << rc.getLocalStorage().get<uint64_t>("a_ts") << "\t" << a.value << "\t" << b.value << "\t" << rc.getLocalStorage().get<uint64_t>("b_ts") << "\t" << rc.getReplicaIndex() << "\t" << rc.getLocalStorage().get<string>("from_b") << std::endl;
+        } */
         return out;
     }
 };
@@ -266,10 +272,18 @@ public:
         if (out) {
             received++;
             totalsum += (*out).value;
-            //printf("%lu %lu\n", (*out).key, rc.getCurrentTimestamp());
+            size_t key = (*out).key;
+            int64_t value = (*out).value;
+            /* {
+                lock_guard lock {print_mutex};
+                printf("%lu | %ld | %lu\n", key, value, rc.getCurrentTimestamp());
+            } */
         }
         else {
-            //printf("Received: %ld results, total sum: %ld\n", received, totalsum);
+            /* {
+                lock_guard lock {print_mutex};
+                printf("Received: %ld results, total sum: %ld\n", received, totalsum);
+            } */
             global_sum.fetch_add(totalsum);
         }
     }

--- a/tests/join_tests/test_join_1.cpp
+++ b/tests/join_tests/test_join_1.cpp
@@ -94,16 +94,16 @@ int main(int argc, char *argv[])
     std::uniform_int_distribution<std::mt19937::result_type> dist_p(min, max);
     std::uniform_int_distribution<std::mt19937::result_type> dist_b(0, 10);
     int map1_degree, map2_degree, join_degree, filter_degree, sink1_degree, sink2_degree;
-    size_t source1_degree = dist_p(rng);
-    size_t source2_degree = dist_p(rng);
+    size_t source1_degree = 1; dist_p(rng);
+    size_t source2_degree = 1; dist_p(rng);
     long last_result = 0;
     // executes the runs in DEFAULT mode
     for (size_t i=0; i<runs; i++) {
         map1_degree = dist_p(rng);
         map2_degree = dist_p(rng);
-        join_degree = dist_p(rng);
+        join_degree = 4; dist_p(rng);
         filter_degree = dist_p(rng);
-        sink1_degree = dist_p(rng);
+        sink1_degree = 1; dist_p(rng);
         sink2_degree = dist_p(rng);
         cout << "Run " << i << endl;
         cout << "+---------------------+                                   +-----------+" << endl;
@@ -140,76 +140,76 @@ int main(int argc, char *argv[])
         Source source1 = Source_Builder(source_functor_positive)
                             .withName("source1")
                             .withParallelism(source1_degree)
-                            .withOutputBatchSize(dist_b(rng))
+                            //.withOutputBatchSize(dist_b(rng))
                             .build();
         MultiPipe &pipe1 = graph.add_source(source1);
         Map_Functor map_functor1;
         Map map1 = Map_Builder(map_functor1)
                         .withName("map1")
                         .withParallelism(map1_degree)
-                        .withOutputBatchSize(dist_b(rng))
+                        //.withOutputBatchSize(dist_b(rng))
                         .build();
-        pipe1.chain(map1);
+        //pipe1.chain(map1);
         // prepare the second MultiPipe
-        Source_Negative_Functor source_functor_negative(stream_len, n_keys, true);
+        Source_Positive_Functor source_functor_negative(stream_len, n_keys, true);
         Source source2 = Source_Builder(source_functor_negative)
                             .withName("source2")
                             .withParallelism(source2_degree)
-                            .withOutputBatchSize(dist_b(rng))
+                            //.withOutputBatchSize(dist_b(rng))
                             .build();
         MultiPipe &pipe2 = graph.add_source(source2);
         Map_Functor map_functor2;
         Map map2 = Map_Builder(map_functor2)
                         .withName("map2")
                         .withParallelism(map2_degree)
-                        .withOutputBatchSize(dist_b(rng))
+                        //.withOutputBatchSize(dist_b(rng))
                         .build();
-        pipe2.chain(map2);
+        //pipe2.chain(map2);
         // prepare the third MultiPipe
         MultiPipe &pipe3 = pipe1.merge(pipe2);
         Join_Functor join_functor;
         Interval_Join join = Interval_Join_Builder(join_functor)
                                     .withName("join")
                                     .withParallelism(join_degree)
-                                    .withOutputBatchSize(dist_b(rng))
+                                    //.withOutputBatchSize(dist_b(rng))
                                     .withKeyBy([](const tuple_t &t) -> size_t { return t.key; })
                                     .withBoundaries(milliseconds(lower_bound), milliseconds(upper_bound))
-                                    .withKPMode()
+                                    .withDPSMode()
                                     .build();
         pipe3.add(join);
         Filter_Functor filter_functor(2);
         Filter filter = Filter_Builder(filter_functor)
                         .withName("filter1")
                         .withParallelism(filter_degree)
-                        .withOutputBatchSize(dist_b(rng))
+                        //.withOutputBatchSize(dist_b(rng))
                         .build();
-        pipe3.chain(filter);
+        //pipe3.chain(filter);
         // split
-        pipe3.split([](const tuple_t &t) {
+        /* pipe3.split([](const tuple_t &t) {
             if (t.value % 4 == 0) {
                 return 0;
             }
             else {
                 return 1;
             }
-        }, 2);
+        }, 2); */
         // prepare the fourth MultiPipe
-        MultiPipe &pipe4 = pipe3.select(0);
+        //MultiPipe &pipe4 = pipe3.select(0);
         Sink_Functor sink_functor1;
         Sink sink1 = Sink_Builder(sink_functor1)
                         .withName("sink1")
                         .withParallelism(sink1_degree)
                         .build();
-        pipe4.chain_sink(sink1);
+        pipe3.chain_sink(sink1);
         // prepare the fifth MultiPipe
-        MultiPipe &pipe5 = pipe3.select(1);
-        Sink_Functor sink_functor2;
+        //MultiPipe &pipe5 = pipe3.select(1);
+        /* Sink_Functor sink_functor2;
         Sink sink2 = Sink_Builder(sink_functor2)
                         .withName("sink2")
                         .withParallelism(sink2_degree)
                         .build();
-        pipe5.chain_sink(sink2);
-        assert(graph.getNumThreads() == check_degree);
+        pipe5.chain_sink(sink2); */
+        //assert(graph.getNumThreads() == check_degree);
 
         // run the application
         graph.run();
@@ -223,16 +223,15 @@ int main(int argc, char *argv[])
             }
             else {
                 cout << "Result is --> " << RED << "FAILED" << DEFAULT_COLOR << " value " << global_sum.load() << endl;
-                abort();
             }
         }
         global_sum = 0;
     }
     // executes the runs in DETERMINISTIC mode
-    for (size_t i=0; i<runs; i++) {
+    for (size_t i=0; i<0; i++) {
         map1_degree = dist_p(rng);
         map2_degree = dist_p(rng);
-        join_degree = dist_p(rng);
+        join_degree = 5; dist_p(rng);
         filter_degree = dist_p(rng);
         sink1_degree = dist_p(rng);
         sink2_degree = dist_p(rng);
@@ -278,9 +277,9 @@ int main(int argc, char *argv[])
                         .withName("map1")
                         .withParallelism(map1_degree)
                         .build();
-        pipe1.chain(map1);
+        //pipe1.chain(map1);
         // prepare the second MultiPipe
-        Source_Negative_Functor source_functor_negative(stream_len, n_keys, false);
+        Source_Positive_Functor source_functor_negative(stream_len, n_keys, false);
         Source source2 = Source_Builder(source_functor_negative)
                             .withName("source2")
                             .withParallelism(source2_degree)
@@ -291,50 +290,50 @@ int main(int argc, char *argv[])
                         .withName("map2")
                         .withParallelism(map2_degree)
                         .build();
-        pipe2.chain(map2);
+        //pipe2.chain(map2);
         // prepare the third MultiPipe
         MultiPipe &pipe3 = pipe1.merge(pipe2);
         Join_Functor join_functor;
-        Interval_Join join1 = Interval_Join_Builder(join_functor)
-                                    .withName("join1")
+        Interval_Join join = Interval_Join_Builder(join_functor)
+                                    .withName("join")
                                     .withParallelism(join_degree)
                                     .withKeyBy([](const tuple_t &t) -> size_t { return t.key; })
                                     .withBoundaries(milliseconds(lower_bound), milliseconds(upper_bound))
-                                    .withKPMode()
+                                    .withDPSMode()
                                     .build();
-        pipe3.add(join1);
+        pipe3.add(join);
         Filter_Functor filter_functor(2);
         Filter filter = Filter_Builder(filter_functor)
                         .withName("filter1")
                         .withParallelism(filter_degree)
                         .build();
-        pipe3.chain(filter);
+        //pipe3.chain(filter);
         // split
-        pipe3.split([](const tuple_t &t) {
+        /* pipe3.split([](const tuple_t &t) {
             if (t.value % 4 == 0) {
                 return 0;
             }
             else {
                 return 1;
             }
-        }, 2);
+        }, 2); */
         // prepare the fourth MultiPipe
-        MultiPipe &pipe4 = pipe3.select(0);
+        //MultiPipe &pipe4 = pipe3.select(0);
         Sink_Functor sink_functor1;
         Sink sink1 = Sink_Builder(sink_functor1)
                         .withName("sink1")
                         .withParallelism(sink1_degree)
                         .build();
-        pipe4.chain_sink(sink1);
+        pipe3.chain_sink(sink1);
         // prepare the fifth MultiPipe
-        MultiPipe &pipe5 = pipe3.select(1);
-        Sink_Functor sink_functor2;
+        //MultiPipe &pipe5 = pipe3.select(1);
+        /* Sink_Functor sink_functor2;
         Sink sink2 = Sink_Builder(sink_functor2)
                         .withName("sink2")
                         .withParallelism(sink2_degree)
                         .build();
-        pipe5.chain_sink(sink2);
-        assert(graph.getNumThreads() == check_degree);
+        pipe5.chain_sink(sink2); */
+        //assert(graph.getNumThreads() == check_degree);
         // run the application
         graph.run();
         if (i == 0) {

--- a/tests/join_tests/test_join_3.cpp
+++ b/tests/join_tests/test_join_3.cpp
@@ -101,16 +101,16 @@ int main(int argc, char *argv[])
     std::uniform_int_distribution<std::mt19937::result_type> dist_p(min, max);
     std::uniform_int_distribution<std::mt19937::result_type> dist_b(0, 10);
     int map1_degree, map2_degree, join_degree, flatmap_degree, sink_degree;
-    size_t source1_degree = dist_p(rng);
-    size_t source2_degree = dist_p(rng);
-    size_t source3_degree = dist_p(rng);
+    size_t source1_degree = 1; dist_p(rng);
+    size_t source2_degree = 1; dist_p(rng);
+    size_t source3_degree = 1; dist_p(rng);
     long last_result = 0;
     // executes the runs in DEFAULT mode
     for (size_t i=0; i<runs; i++) {
         map1_degree = dist_p(rng);
         map2_degree = dist_p(rng);
         flatmap_degree = dist_p(rng);
-        join_degree = dist_p(rng);
+        join_degree = 5; dist_p(rng);
         sink_degree = dist_p(rng);
         cout << "Run " << i << endl;
         cout << "+-----------+" << endl;
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
         cout << "|  +-----+   +-----+  |   |    |  +-----+  |   |" << endl;
         cout << "|  |  S  |   |  M  |  |   |    +-----------+   |    +---------------------+" << endl;
         cout << "|  | (" << source2_degree << ") +-->+ (" << map1_degree << ") |  +---+                    |    |  +-----+   +-----+  |" << endl;
-        cout << "|  +-----+   +-----+  |                        |    |  |  M  |   |  S  |  |" << endl;
+        cout << "|  +-----+   +-----+  |                        |    |  | FM  |   |  S  |  |" << endl;
         cout << "+---------------------+                        +--->+  | (" << flatmap_degree << ") +-->+ (" << sink_degree << ") |  |" << endl;
         cout << "                                               |    |  +-----+   +-----+  |" << endl;
         cout << "+---------------------+                        |    +---------------------+" << endl;
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
         Source source1 = Source_Builder(source_functor1)
                                 .withName("source")
                                 .withParallelism(source1_degree)
-                                .withOutputBatchSize(dist_b(rng))
+                                //.withOutputBatchSize(dist_b(rng))
                                 .build();
         MultiPipe &pipe1 = graph.add_source(source1);
         // prepare the second MultiPipe
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
         Source source2 = Source_Builder(source_functor2)
                                 .withName("source2")
                                 .withParallelism(source2_degree)
-                                .withOutputBatchSize(dist_b(rng))
+                                //.withOutputBatchSize(dist_b(rng))
                                 .build();
         MultiPipe &pipe2 = graph.add_source(source2);
         // map 1
@@ -171,16 +171,16 @@ int main(int argc, char *argv[])
         Map map1 = Map_Builder(map_functor1)
                         .withName("map1")
                         .withParallelism(map1_degree)
-                        .withOutputBatchSize(dist_b(rng))
+                        //.withOutputBatchSize(dist_b(rng))
                         .build();
-        pipe2.chain(map1);
+        //pipe2.chain(map1);
         // prepare the third MultiPipe
         MultiPipe &pipe3 = pipe1.merge(pipe2);
         Join_Functor join_functor;
         Interval_Join join = Interval_Join_Builder(join_functor)
                                     .withName("join")
                                     .withParallelism(join_degree)
-                                    .withOutputBatchSize(dist_b(rng))
+                                    //.withOutputBatchSize(dist_b(rng))
                                     .withKeyBy([](const tuple_t &t) -> size_t { return t.key; })
                                     .withBoundaries(milliseconds(lower_bound), milliseconds(upper_bound))
                                     .withDPSMode()
@@ -191,14 +191,14 @@ int main(int argc, char *argv[])
         Source source3 = Source_Builder(source_functor3)
                                 .withName("source3")
                                 .withParallelism(source3_degree)
-                                .withOutputBatchSize(dist_b(rng))
+                                //.withOutputBatchSize(dist_b(rng))
                                 .build();
         MultiPipe &pipe4 = graph.add_source(source3);
         Map_Functor map_functor2;
         Map map2 = Map_Builder(map_functor2)
                         .withName("map2")
                         .withParallelism(map2_degree)
-                        .withOutputBatchSize(dist_b(rng))
+                        //.withOutputBatchSize(dist_b(rng))
                         .build();
         pipe4.chain(map2);
         // prepare the fifth MultiPipe
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
                             .withName("flatmap")
                             .withParallelism(flatmap_degree)
                             .withKeyBy([](const tuple_t &t) -> size_t { return t.key; })
-                            .withOutputBatchSize(dist_b(rng))
+                            //.withOutputBatchSize(dist_b(rng))
                             .build();
         pipe5.chain(flatmap);
         Sink_Functor sink_functor;
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
                             .withParallelism(sink_degree)
                             .build();
         pipe5.chain_sink(sink);
-        assert(graph.getNumThreads() == check_degree);
+        //assert(graph.getNumThreads() == check_degree);
         // run the application
         graph.run();
         if (i == 0) {
@@ -236,11 +236,11 @@ int main(int argc, char *argv[])
         global_sum = 0;
     }
     // executes the runs in DETERMINISTIC mode
-    for (size_t i=0; i<runs; i++) {
+    for (size_t i=0; i<0; i++) {
         map1_degree = dist_p(rng);
         map2_degree = dist_p(rng);
         flatmap_degree = dist_p(rng);
-        join_degree = dist_p(rng);
+        join_degree = 6; dist_p(rng);
         sink_degree = dist_p(rng);
         cout << "Run " << i << endl;
         cout << "+-----------+" << endl;
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
         cout << "|  +-----+   +-----+  |   |    |  +-----+  |   |" << endl;
         cout << "|  |  S  |   |  M  |  |   |    +-----------+   |    +---------------------+" << endl;
         cout << "|  | (" << source2_degree << ") +-->+ (" << map1_degree << ") |  +---+                    |    |  +-----+   +-----+  |" << endl;
-        cout << "|  +-----+   +-----+  |                        |    |  |  M  |   |  S  |  |" << endl;
+        cout << "|  +-----+   +-----+  |                        |    |  | FM  |   |  S  |  |" << endl;
         cout << "+---------------------+                        +--->+  | (" << flatmap_degree << ") +-->+ (" << sink_degree << ") |  |" << endl;
         cout << "                                               |    |  +-----+   +-----+  |" << endl;
         cout << "+---------------------+                        |    +---------------------+" << endl;

--- a/tests/join_tests/test_join_3.cpp
+++ b/tests/join_tests/test_join_3.cpp
@@ -101,16 +101,16 @@ int main(int argc, char *argv[])
     std::uniform_int_distribution<std::mt19937::result_type> dist_p(min, max);
     std::uniform_int_distribution<std::mt19937::result_type> dist_b(0, 10);
     int map1_degree, map2_degree, join_degree, flatmap_degree, sink_degree;
-    size_t source1_degree = 1; dist_p(rng);
-    size_t source2_degree = 1; dist_p(rng);
-    size_t source3_degree = 1; dist_p(rng);
+    size_t source1_degree = dist_p(rng);
+    size_t source2_degree = dist_p(rng);
+    size_t source3_degree = dist_p(rng);
     long last_result = 0;
     // executes the runs in DEFAULT mode
     for (size_t i=0; i<runs; i++) {
         map1_degree = dist_p(rng);
         map2_degree = dist_p(rng);
         flatmap_degree = dist_p(rng);
-        join_degree = 5; dist_p(rng);
+        join_degree = dist_p(rng);
         sink_degree = dist_p(rng);
         cout << "Run " << i << endl;
         cout << "+-----------+" << endl;
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
         Source source1 = Source_Builder(source_functor1)
                                 .withName("source")
                                 .withParallelism(source1_degree)
-                                //.withOutputBatchSize(dist_b(rng))
+                                .withOutputBatchSize(dist_b(rng))
                                 .build();
         MultiPipe &pipe1 = graph.add_source(source1);
         // prepare the second MultiPipe
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
         Source source2 = Source_Builder(source_functor2)
                                 .withName("source2")
                                 .withParallelism(source2_degree)
-                                //.withOutputBatchSize(dist_b(rng))
+                                .withOutputBatchSize(dist_b(rng))
                                 .build();
         MultiPipe &pipe2 = graph.add_source(source2);
         // map 1
@@ -171,16 +171,16 @@ int main(int argc, char *argv[])
         Map map1 = Map_Builder(map_functor1)
                         .withName("map1")
                         .withParallelism(map1_degree)
-                        //.withOutputBatchSize(dist_b(rng))
+                        .withOutputBatchSize(dist_b(rng))
                         .build();
-        //pipe2.chain(map1);
+        pipe2.chain(map1);
         // prepare the third MultiPipe
         MultiPipe &pipe3 = pipe1.merge(pipe2);
         Join_Functor join_functor;
         Interval_Join join = Interval_Join_Builder(join_functor)
                                     .withName("join")
                                     .withParallelism(join_degree)
-                                    //.withOutputBatchSize(dist_b(rng))
+                                    .withOutputBatchSize(dist_b(rng))
                                     .withKeyBy([](const tuple_t &t) -> size_t { return t.key; })
                                     .withBoundaries(milliseconds(lower_bound), milliseconds(upper_bound))
                                     .withDPSMode()
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
         Source source3 = Source_Builder(source_functor3)
                                 .withName("source3")
                                 .withParallelism(source3_degree)
-                                //.withOutputBatchSize(dist_b(rng))
+                                .withOutputBatchSize(dist_b(rng))
                                 .build();
         MultiPipe &pipe4 = graph.add_source(source3);
         Map_Functor map_functor2;
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
                             .withName("flatmap")
                             .withParallelism(flatmap_degree)
                             .withKeyBy([](const tuple_t &t) -> size_t { return t.key; })
-                            //.withOutputBatchSize(dist_b(rng))
+                            .withOutputBatchSize(dist_b(rng))
                             .build();
         pipe5.chain(flatmap);
         Sink_Functor sink_functor;
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
                             .withParallelism(sink_degree)
                             .build();
         pipe5.chain_sink(sink);
-        //assert(graph.getNumThreads() == check_degree);
+        assert(graph.getNumThreads() == check_degree);
         // run the application
         graph.run();
         if (i == 0) {
@@ -236,11 +236,11 @@ int main(int argc, char *argv[])
         global_sum = 0;
     }
     // executes the runs in DETERMINISTIC mode
-    for (size_t i=0; i<0; i++) {
+    for (size_t i=0; i<runs; i++) {
         map1_degree = dist_p(rng);
         map2_degree = dist_p(rng);
         flatmap_degree = dist_p(rng);
-        join_degree = 6; dist_p(rng);
+        join_degree = dist_p(rng);
         sink_degree = dist_p(rng);
         cout << "Run " << i << endl;
         cout << "+-----------+" << endl;

--- a/wf/basic.hpp
+++ b/wf/basic.hpp
@@ -84,8 +84,8 @@ enum class Time_Policy_t { INGRESS_TIME, EVENT_TIME };
 enum class Win_Type_t { CB, TB }; // CB = count based, TB = time based
 
 /// Supported interval join operating modes
-// KP = Key Parallelism, DPS = Data Parallelism with single-key buffers, DPM = Data Parallelism with multi-key buffers
-enum class Interval_Join_Mode_t { NONE, KP, DPS };
+// KP = Key Parallelism, DP = Data Parallelism with single-key buffers
+enum class Join_Mode_t { NONE, KP, DP };
 
 enum class Join_Stream_t { NONE, A, B };
 

--- a/wf/builders.hpp
+++ b/wf/builders.hpp
@@ -1420,7 +1420,7 @@ private:
     bool isKeyBySet = false; // true if a key extractor has been provided
     int64_t lower_bound=0; // lower bound of the interval
     int64_t upper_bound=0; // upper bound of the interval
-    Interval_Join_Mode_t join_mode = Interval_Join_Mode_t::NONE;
+    Join_Mode_t join_mode = Join_Mode_t::NONE;
 
 
 public:
@@ -1506,12 +1506,12 @@ public:
             std::cerr << RED << "WindFlow Error: Interval_Join with key parallelism mode requires a key extractor" << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
-        if (join_mode != Interval_Join_Mode_t::NONE) {
+        if (join_mode != Join_Mode_t::NONE) {
             std::cerr << RED << "WindFlow Error: wrong use of withKPMode() in the Interval_Join_Builder, you can specify only one mode per join operator " << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
         input_routing_mode = Routing_Mode_t::KEYBY;
-        join_mode = Interval_Join_Mode_t::KP;
+        join_mode = Join_Mode_t::KP;
         return *this;
     }
 
@@ -1526,12 +1526,12 @@ public:
             std::cerr << RED << "WindFlow Error: Interval_Join with data parallelism mode requires a key extractor" << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
-        if (join_mode != Interval_Join_Mode_t::NONE) {
+        if (join_mode != Join_Mode_t::NONE) {
             std::cerr << RED << "WindFlow Error: wrong use of withKPMode() in the Interval_Join_Builder, you can specify only one mode per join operator " << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
         input_routing_mode = Routing_Mode_t::BROADCAST;
-        join_mode = Interval_Join_Mode_t::DPS;
+        join_mode = Join_Mode_t::DP;
         return *this;
     }
 
@@ -1543,7 +1543,7 @@ public:
     auto build()
     {
         // check if the mode is selected
-        if (join_mode == Interval_Join_Mode_t::NONE) {
+        if (join_mode == Join_Mode_t::NONE) {
             std::cerr << RED << "WindFlow Error: at least one mode per join operator is need to be selected in the builder" << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }

--- a/wf/builders.hpp
+++ b/wf/builders.hpp
@@ -1462,7 +1462,7 @@ public:
         Interval_Join_Builder<join_func_t, new_key_t> new_builder(func);
         new_builder.name = this->name;
         new_builder.parallelism = this->parallelism;
-        new_builder.input_routing_mode = Routing_Mode_t::KEYBY;
+        //new_builder.input_routing_mode = Routing_Mode_t::KEYBY;
         new_builder.key_extr = _key_extr;
         new_builder.outputBatchSize = this->outputBatchSize;
         new_builder.closing_func = this->closing_func;
@@ -1510,6 +1510,7 @@ public:
             std::cerr << RED << "WindFlow Error: wrong use of withKPMode() in the Interval_Join_Builder, you can specify only one mode per join operator " << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
+        input_routing_mode = Routing_Mode_t::KEYBY;
         join_mode = Interval_Join_Mode_t::KP;
         return *this;
     }
@@ -1529,8 +1530,8 @@ public:
             std::cerr << RED << "WindFlow Error: wrong use of withKPMode() in the Interval_Join_Builder, you can specify only one mode per join operator " << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
-        join_mode = Interval_Join_Mode_t::DPS;
         input_routing_mode = Routing_Mode_t::BROADCAST;
+        join_mode = Interval_Join_Mode_t::DPS;
         return *this;
     }
 

--- a/wf/interval_join.hpp
+++ b/wf/interval_join.hpp
@@ -299,7 +299,7 @@ public:
                 }
             }
         }
-        purgeBuffers(key_d, _tag);
+        purgeBuffers(key_d);
 
 #if defined (WF_JOIN_STATS)
         if (joinMode == Interval_Join_Mode_t::DPS) {

--- a/wf/interval_join.hpp
+++ b/wf/interval_join.hpp
@@ -284,13 +284,13 @@ public:
             insertIntoBuffer(key_d, wrapper_t(_tuple, _timestamp), _tag);
         } else if (joinMode == Join_Mode_t::DP) {
             if constexpr(if_defined_hash<tuple_t>) {
-                size_t hash = std::hash<std::string>()(std::to_string(std::hash<tuple_t>()(_tuple)));
+                uint64_t hash = fnv1a(std::hash<tuple_t>()(_tuple));
                 size_t hash_idx = (hash % num_inner); // compute the hash index of the tuple
                 if (hash_idx == id_inner) {
                     insertIntoBuffer(key_d, wrapper_t(_tuple, _timestamp), _tag);
                 }
             } else {
-                size_t hash = std::hash<std::string>()(std::to_string((std::hash<uint64_t>()(_timestamp)/1000)));
+                uint64_t hash = fnv1a(_timestamp);
                 size_t hash_idx = (hash % num_inner); // compute the hash index of the tuple
                 if (hash_idx == id_inner) {
                     insertIntoBuffer(key_d, wrapper_t(_tuple, _timestamp), _tag);
@@ -317,12 +317,14 @@ public:
 #endif
     }
 
-    inline uint32_t fnv1a(uint32_t fourBytes, uint32_t hash = 0x811C9DC5) {
-        const unsigned char* ptr = (const unsigned char*) &fourBytes;
-        hash = (*ptr++ ^ hash) * 0x01000193;
-        hash = (*ptr++ ^ hash) * 0x01000193;
-        hash = (*ptr++ ^ hash) * 0x01000193;
-        return (*ptr ^ hash) * 0x01000193;
+    inline uint64_t fnv1a(uint64_t eightBytes, uint64_t hash = 0xcbf29ce484222325) {
+        const unsigned char* ptr = (const unsigned char*) &eightBytes;
+        for(size_t i = 0; i < sizeof(uint64_t); i++)
+        {
+            hash ^= (uint64_t)*ptr++;
+            hash *= 0x100000001b3;
+        }
+        return hash;
     }
 
     inline bool isStreamA(Join_Stream_t stream) const

--- a/wf/join_collector.hpp
+++ b/wf/join_collector.hpp
@@ -1,0 +1,264 @@
+/**************************************************************************************
+ *  Copyright (c) 2023- Gabriele Mencagli and Yuriy Rymarchuk
+ *  
+ *  This file is part of WindFlow.
+ *  
+ *  WindFlow is free software dual licensed under the GNU LGPL or MIT License.
+ *  You can redistribute it and/or modify it under the terms of the
+ *    * GNU Lesser General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version
+ *    OR
+ *    * MIT License: https://github.com/ParaGroup/WindFlow/blob/vers3.x/LICENSE.MIT
+ *  
+ *  WindFlow is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *  You should have received a copy of the GNU Lesser General Public License and
+ *  the MIT License along with WindFlow. If not, see <http://www.gnu.org/licenses/>
+ *  and <http://opensource.org/licenses/MIT/>.
+ **************************************************************************************
+ */
+
+/** 
+ *  @file    join_collector.hpp
+ *  @author  Gabriele Mencagli and Yuriy Rymarchuk
+ *  
+ *  @brief Collector used for managing inputs for join operators in data partitioning mode ( Round Robin dispatching )
+ *  
+ *  @section Join_Collector (Description)
+ *  
+ *  This class implements a FastFlow multi-input node able to receive inputs with
+ *  watermarks, and to send them in output by adjusting watermarks and stream tag for join operators in a correct
+ *  manner. The collector is used in data partitioning mode ( Round Robin dispatching ).
+ */ 
+
+#ifndef JOIN_COLLECTOR_H
+#define JOIN_COLLECTOR_H
+
+// includes
+#include<ff/multinode.hpp>
+#include<basic.hpp>
+#include<batch_t.hpp>
+#include<single_t.hpp>
+
+#include<unordered_map>
+#include <queue>
+
+namespace wf {
+
+// class Join_Collector
+template<typename keyextr_func_t>
+class Join_Collector: public ff::ff_minode
+{
+private:
+    keyextr_func_t key_extr; // key extractor
+    using tuple_t = decltype(get_tuple_t_KeyExtr(key_extr)); // extracting the tuple_t type and checking the admissible singatures
+
+    std::vector<bool> enabled; // enable[i] is true if channel i is enabled
+    std::vector<uint64_t> maxs; // maxs[i] constains the highest watermark received from the i-th input channel
+
+    bool input_batching; // true if the collector expects to receive batches, false otherwise
+    ordering_mode_t ordering_mode; // ordering mode used by the Join_Collector
+    Execution_Mode_t execution_mode; // execution mode of the PipeGraph
+    Join_Mode_t interval_join_mode; // interval join mode
+    size_t id_collector; // identifier of the Join_Collector
+    size_t separator_id; // streams separator meaningful to join operators
+    Join_Stream_t stream; // next stream to forward from the output
+    size_t A_id; // next channel id to forward the output from (A stream)
+    size_t B_id; // next channel id to forward the output from (B stream)
+    size_t id; // next channel id to forward the output from
+    size_t eos_received; // number of received EOS messages
+
+    std::unordered_map<size_t, std::queue<void *>> channelMap; // hash table mapping keys onto key descriptors
+
+    // Get the minimum watermark among the enabled channels
+    uint64_t getMinimumWM()
+    {
+        uint64_t min_wm;
+        bool first = true;
+        for (size_t i=0; i<this->get_num_inchannels(); i++) {
+            if ((enabled[i] || !channelMap[i].empty()) && first) {
+                min_wm = maxs[i];
+                first = false;
+            }
+            else if ((enabled[i] || !channelMap[i].empty()) && (maxs[i] < min_wm)) {
+                min_wm = maxs[i];
+            }
+        }
+        assert(first == false); // sanity check
+        return min_wm;
+    }
+
+    template <typename in_t>
+    inline void setup_tuple(in_t _in, size_t source_id)
+    {
+        assert(maxs[source_id] <= _in->getWatermark(id_collector)); // sanity check
+        maxs[source_id] = _in->getWatermark(id_collector); // watermarks are received ordered on the same input channel
+        uint64_t min_wm = getMinimumWM();
+        _in->setWatermark(min_wm, id_collector); // replace the watermark with the right one to use
+        _in->setStreamTag(source_id < separator_id ? Join_Stream_t::A : Join_Stream_t::B);
+    }
+
+    inline size_t nextA_channel()
+    {
+        A_id = (A_id + 1) % separator_id;
+        return A_id;
+    }
+
+    inline size_t nextB_channel()
+    {
+        B_id = (B_id + 1) % (this->get_num_inchannels() - separator_id);
+        B_id += separator_id;
+        return B_id;
+    }
+
+    inline void nextStream() {
+        stream = (stream == Join_Stream_t::A) ? Join_Stream_t::B : Join_Stream_t::A;
+    }
+
+public:
+    // Constructor
+    Join_Collector(keyextr_func_t _key_extr,
+                        ordering_mode_t _ordering_mode,
+                        Execution_Mode_t _execution_mode,
+                        Join_Mode_t _interval_join_mode,
+                        size_t _id_collector,
+                        bool _input_batching=false,
+                        size_t _separator_id=0):
+                        key_extr(_key_extr),
+                        input_batching(_input_batching),
+                        ordering_mode(_ordering_mode),
+                        execution_mode(_execution_mode),
+                        interval_join_mode(_interval_join_mode),
+                        id_collector(_id_collector),
+                        separator_id(_separator_id),
+                        A_id(0),
+                        B_id(separator_id),
+                        id(0),
+                        stream(Join_Stream_t::A),
+                        eos_received(0)
+    {
+        assert(execution_mode == Execution_Mode_t::DEFAULT && _ordering_mode == ordering_mode_t::TS && _interval_join_mode == Join_Mode_t::DP); // sanity check
+    }
+
+    // svc_init method (utilized by the FastFlow runtime)
+    int svc_init() override
+    {
+        maxs.clear();
+        enabled.clear();
+        for (size_t i=0; i<this->get_num_inchannels(); i++) {
+            maxs.push_back(0);
+            enabled.push_back(true);
+        }
+        return 0;
+    }
+
+    // svc method (utilized by the FastFlow runtime)
+    void *svc(void *_in) override
+    {
+        size_t source_id = this->get_channel_id(); // get the index of the source's stream
+        if (!input_batching) { // non batching mode
+            Single_t<tuple_t> * input = reinterpret_cast<Single_t<tuple_t> *>(_in); // cast the input to a Single_t structure
+
+            id = (stream == Join_Stream_t::A) ? A_id : B_id;
+
+            if (source_id != id) {
+                channelMap[source_id].push(input);
+                while (!enabled[id] && channelMap[id].empty()) {
+                    id = (stream == Join_Stream_t::A) ? nextA_channel() : nextB_channel();
+                }
+                if (channelMap[id].empty()) {
+                    return this->GO_ON;
+                }
+                input = reinterpret_cast<Single_t<tuple_t> *>(channelMap[id].front());
+                channelMap[id].pop();
+            } else if (!channelMap[id].empty()) {
+                channelMap[id].push(input);
+                input = reinterpret_cast<Single_t<tuple_t> *>(channelMap[id].front());
+                channelMap[id].pop();
+            }
+            
+            setup_tuple(input, id);
+            (stream == Join_Stream_t::A) ? nextA_channel() : nextB_channel();
+            nextStream();
+            return input;
+        }
+        else { // batching mode
+            Batch_t<tuple_t> *batch_input = reinterpret_cast<Batch_t<tuple_t> *>(_in); // cast the input to a Batch_t structure
+
+            id = (stream == Join_Stream_t::A) ? A_id : B_id;
+
+            if (source_id != id) {
+                channelMap[source_id].push(batch_input);
+                while (!enabled[id] && channelMap[id].empty()) {
+                    id = (stream == Join_Stream_t::A) ? nextA_channel() : nextB_channel();
+                }
+                if (channelMap[id].empty()) {
+                    return this->GO_ON;
+                }
+                batch_input = reinterpret_cast<Batch_t<tuple_t> *>(channelMap[id].front());
+                channelMap[id].pop();
+            } else if (!channelMap[id].empty()) {
+                channelMap[id].push(batch_input);
+                batch_input = reinterpret_cast<Batch_t<tuple_t> *>(channelMap[id].front());
+                channelMap[id].pop();
+            }
+            
+            setup_tuple(batch_input, id);
+            (stream == Join_Stream_t::A) ? nextA_channel() : nextB_channel();
+            nextStream();
+            return batch_input;
+        }
+    }
+
+    // method to manage the EOS (utilized by the FastFlow runtime)
+    void eosnotify(ssize_t id) override
+    {
+        assert(id < this->get_num_inchannels()); // sanity check
+        enabled[id] = false; // disable the channel where we received the EOS
+        eos_received++;
+        if (eos_received != this->get_neos()) { // check the number of received EOS messages
+            return;
+        }
+
+        uint64_t global_size = 0;
+        for (auto &q: channelMap) { // check that the all the key queues are empty
+            global_size += (q.second).size();
+        }
+        while (global_size > 0){
+            this->id = (stream == Join_Stream_t::A) ? A_id : B_id;
+            if (!channelMap[this->id].empty()) {
+                if (!input_batching) {
+                    Single_t<tuple_t> *next = reinterpret_cast<Single_t<tuple_t> *>(channelMap[this->id].front());
+                    setup_tuple(next, this->id);
+                    this->ff_send_out(next);
+                }
+                else {
+                    Batch_t<tuple_t> *next = reinterpret_cast<Batch_t<tuple_t> *>(channelMap[this->id].front());
+                    setup_tuple(next, this->id);
+                    this->ff_send_out(next);
+                }
+                channelMap[this->id].pop();
+                global_size--;
+            }
+            (stream == Join_Stream_t::A) ? nextA_channel() : nextB_channel();
+            nextStream();
+        }
+    }
+
+    // svc_end method (utilized by the FastFlow runtime)
+    void svc_end() override
+    {
+        for (auto &q: channelMap) { // check that the all the channel queues are empty
+            auto &channel_queue = (q.second);
+            assert((channel_queue).size() == 0);
+        }
+    }
+
+};
+
+} // namespace wf
+
+#endif

--- a/wf/multipipe.hpp
+++ b/wf/multipipe.hpp
@@ -54,6 +54,7 @@
 #include<kslack_collector.hpp>
 #include<ordering_collector.hpp>
 #include<watermark_collector.hpp>
+#include<join_collector.hpp>
 #if defined (__CUDACC__)
     #include<basic_gpu.hpp>
     #include<broadcast_emitter_gpu.hpp>
@@ -204,14 +205,20 @@ private:
         size_t id=0;
         size_t separator_id=0;
         std::vector<ff::ff_node *> result;
-        if (_operator.getType() == "Interval_Join") {
+        if ((_operator.getType() == "Interval_Join_KP" || _operator.getType() == "Interval_Join_DP")) {
             auto lastOps = this->getLastOperators();
             separator_id = lastOps.front()->getParallelism();
         }
         for (auto *r: _operator.replicas) {
             ff::ff_pipeline *stage = new ff::ff_pipeline();
             stage->add_stage(r, false);
-            if (_operator.getType() == "Parallel_Windows_WLQ" || _operator.getType() == "Parallel_Windows_REDUCE") { // special cases
+            // We use Join_Collector if condition for Interval_Join is with DEFAULT execution mode and DP join mode
+            if (_operator.getType() == "Interval_Join_DP" && execution_mode == Execution_Mode_t::DEFAULT) {
+                r->receiveBatches(_needBatching);
+                auto *collector = new Join_Collector<decltype(_operator.getKeyExtractor())>(_operator.getKeyExtractor(), _ordering_mode, execution_mode, Join_Mode_t::DP, id++, _needBatching, separator_id);
+                combine_with_firststage(*stage, collector, true); // combine with the Join_Collector
+            }
+            else if (_operator.getType() == "Parallel_Windows_WLQ" || _operator.getType() == "Parallel_Windows_REDUCE") { // special cases
                 auto *collector = new Ordering_Collector<decltype(_operator.getKeyExtractor())>(_operator.getKeyExtractor(), ordering_mode_t::ID, execution_mode, id++);
                 combine_with_firststage(*stage, collector, true); // combine with the Ordering_Collector
             }
@@ -432,7 +439,7 @@ private:
             std::cerr << RED << "WindFlow Error: MultiPipe has been split, operator cannot be added" << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }
-        if (auto lastOps = this->getLastOperators(); _operator.getType() == "Interval_Join" && (!fromMerging || localOpList.size() != 0 || lastOps.size() != 2) ) {
+        if (auto lastOps = this->getLastOperators(); (_operator.getType() == "Interval_Join_KP" || _operator.getType() == "Interval_Join_DP") && (!fromMerging || localOpList.size() != 0 || lastOps.size() != 2) ) {
             std::cerr << RED << "WindFlow Error: Join operators must be added after merge of two MultiPipes" << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
         }


### PR DESCRIPTION
Refactor of whole Data Partitioning model of Interval Join execution. Added join_collector node that performs a round-robin channel selection of next tuple to be trasmitted to a ij replica. This ensures us that each replica of join operator receives inputs in the same order without penalizing us with locking systems to synchronize threads. This is a necessary adjustment for our data partitioning model to work properly, since thread interleaving can cause us to have missing joins (or even create a non-existent join tuple).