### PR TITLE
[ADD] Archive metrics refactor

### DIFF
--- a/tests/join_tests/CMakeLists.txt
+++ b/tests/join_tests/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g -finline-functions")
 
 # Macros to be provided to the compiler
-add_definitions(-DFF_BOUNDED_BUFFER -DWF_DP_JOIN_MEASUREMENT)
-# -DWF_DP_JOIN_MEASUREMENT to enable the measurement of how uniformerly the tuples are distributed among the joiners
+add_definitions(-DFF_BOUNDED_BUFFER -DWF_JOIN_MEASUREMENT)
+# -DWF_JOIN_MEASUREMENT to enable the measurement of how uniformerly the tuples are distributed among the joiners
 # -DWF_TRACING_ENABLED to enable the tracing with Dashboard
 
 # Header files of WindFlow and FastFlow

--- a/wf/builders.hpp
+++ b/wf/builders.hpp
@@ -1486,8 +1486,10 @@ public:
     {
         //The lower and upper bounds are inclusive in the interval join range.
         //The +-1 ensures that the bounds are inclusive when retrieving the join range using lower_bound algorithm.
-        lower_bound = _lower_bound.count()-1;
-        upper_bound = _upper_bound.count()+1;
+        _lower_bound -= std::chrono::microseconds(1);
+        lower_bound = _lower_bound.count();
+        _upper_bound += std::chrono::microseconds(1);
+        upper_bound = _upper_bound.count();
         if (lower_bound > upper_bound) {
             std::cerr << RED << "WindFlow Error: Interval_Join must have lower_bound <= upper_bound" << DEFAULT_COLOR << std::endl;
             exit(EXIT_FAILURE);
@@ -1496,7 +1498,7 @@ public:
     }
 
     /** 
-     *  \brief Set Key Parallelism mode for join operator
+     *  \brief Set Key Partitioning mode for join operator
      *  
      *  \return a reference to the builder object
      */ 
@@ -1516,7 +1518,7 @@ public:
     }
 
     /** 
-     *  \brief Set Key Parallelism mode for join operator
+     *  \brief Set Data Partitioning mode for join operator
      *  
      *  \return a reference to the builder object
      */ 


### PR DESCRIPTION
Made more concise functions and structures naming

The commit refactors the archive size measurement logic in the interval join code to provide more fine-grained measurements. This change improves the accuracy of archive size calculations and ensures more precise tracking of archive metrics